### PR TITLE
Better parsing of haxe error messages

### DIFF
--- a/HaxeBinding/Tools/NMECommandLineToolsManager.cs
+++ b/HaxeBinding/Tools/NMECommandLineToolsManager.cs
@@ -25,11 +25,11 @@ namespace MonoDevelop.HaxeBinding.Tools
 		
 		private static Regex mErrorFull = new Regex (@"^(?<file>.+)\((?<line>\d+)\):\s(col:\s)?(?<column>\d*)\s?(?<level>\w+):\s(?<message>.*)\.?$", RegexOptions.Compiled | RegexOptions.ExplicitCapture);
 
-		// test.hx:11: character 7 : Unterminated string
+		// example: test.hx:11: character 7 : Unterminated string
 		private static Regex mErrorFileChar = new Regex (@"^(?<file>.+):(?<line>\d+):\s(character\s)(?<column>\d*)\s:\s(?<message>.*)\.?$", RegexOptions.Compiled | RegexOptions.ExplicitCapture);
-		// test.hx:11: characters 0-5 : Unexpected class
+		// example: test.hx:11: characters 0-5 : Unexpected class
 		private static Regex mErrorFileChars = new Regex (@"^(?<file>.+):(?<line>\d+):\s(characters\s)(?<column>\d+)-(\d+)\s:\s(?<message>.*)\.?$", RegexOptions.Compiled | RegexOptions.ExplicitCapture);
-		// test.hx:10: lines 10-28 : Class not found : Sprit
+		// example: test.hx:10: lines 10-28 : Class not found : Sprit
 		private static Regex mErrorFile = new Regex (@"^(?<file>.+):(?<line>\d+):\s(?<message>.*)\.?$", RegexOptions.Compiled | RegexOptions.ExplicitCapture);
 		
 		private static Regex mErrorCmdLine = new Regex (@"^command line: (?<level>\w+):\s(?<message>.*)\.?$", RegexOptions.Compiled | RegexOptions.ExplicitCapture);

--- a/HaxeBinding/Tools/NMECommandLineToolsManager.cs
+++ b/HaxeBinding/Tools/NMECommandLineToolsManager.cs
@@ -24,7 +24,14 @@ namespace MonoDevelop.HaxeBinding.Tools
 		private static DateTime cacheNMMLTime;
 		
 		private static Regex mErrorFull = new Regex (@"^(?<file>.+)\((?<line>\d+)\):\s(col:\s)?(?<column>\d*)\s?(?<level>\w+):\s(?<message>.*)\.?$", RegexOptions.Compiled | RegexOptions.ExplicitCapture);
+
+		// test.hx:11: character 7 : Unterminated string
+		private static Regex mErrorFileChar = new Regex (@"^(?<file>.+):(?<line>\d+):\s(character\s)(?<column>\d*)\s:\s(?<message>.*)\.?$", RegexOptions.Compiled | RegexOptions.ExplicitCapture);
+		// test.hx:11: characters 0-5 : Unexpected class
+		private static Regex mErrorFileChars = new Regex (@"^(?<file>.+):(?<line>\d+):\s(characters\s)(?<column>\d+)-(\d+)\s:\s(?<message>.*)\.?$", RegexOptions.Compiled | RegexOptions.ExplicitCapture);
+		// test.hx:10: lines 10-28 : Class not found : Sprit
 		private static Regex mErrorFile = new Regex (@"^(?<file>.+):(?<line>\d+):\s(?<message>.*)\.?$", RegexOptions.Compiled | RegexOptions.ExplicitCapture);
+		
 		private static Regex mErrorCmdLine = new Regex (@"^command line: (?<level>\w+):\s(?<message>.*)\.?$", RegexOptions.Compiled | RegexOptions.ExplicitCapture);
 		private static Regex mErrorSimple = new Regex (@"^(?<level>\w+):\s(?<message>.*)\.?$", RegexOptions.Compiled | RegexOptions.ExplicitCapture);
 		private static Regex mErrorIgnore = new Regex (@"^(Updated|Recompile|Reason|Files changed):.*", RegexOptions.Compiled);
@@ -79,7 +86,12 @@ namespace MonoDevelop.HaxeBinding.Tools
 			if (!match.Success)
 				match = mErrorCmdLine.Match (text);
 			if (!match.Success)
+				match = mErrorFileChar.Match (text);
+			if (!match.Success)
+				match = mErrorFileChars.Match (text);
+			if (!match.Success)
 				match = mErrorFile.Match (text);
+			    
 			if (!match.Success)
 				match = mErrorSimple.Match (text);
 			if (!match.Success)
@@ -117,7 +129,7 @@ namespace MonoDevelop.HaxeBinding.Tools
 				error.Line = 0;
 
 			if (Int32.TryParse (match.Result ("${column}"), out n))
-				error.Column = n;
+				error.Column = n+1; //haxe counts zero based
 			else
 				error.Column = -1;
 


### PR DESCRIPTION
Hi Joshua,

I made a couple of changes to correctly parse column information from the haxe error messages.

I hope this is helpful. I am not sure if we need the other Regex that we have in there. For example, what happens if we get c++ compiler errors?

Best,
Timo
