### PR TITLE
Autocompletion bugfix for classpaths containing spaces.

### DIFF
--- a/HaxeBinding/HaxeBinding.csproj
+++ b/HaxeBinding/HaxeBinding.csproj
@@ -36,18 +36,6 @@
     </Reference>
     <Reference Include="gdk-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f" />
     <Reference Include="System.Xml" />
-    <Reference Include="Mono.TextEditor, Version=1.0.0.0, Culture=neutral">
-      <HintPath>\Applications\MonoDevelop.app\Contents\MacOS\lib\monodevelop\bin\Mono.TextEditor.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="MonoDevelop.DesignerSupport, Version=2.6.0.0, Culture=neutral">
-      <HintPath>\Applications\MonoDevelop.app\Contents\MacOS\lib\monodevelop\AddIns\MonoDevelop.DesignerSupport\MonoDevelop.DesignerSupport.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="MonoDevelop.Refactoring, Version=2.6.0.0, Culture=neutral">
-      <HintPath>\Applications\MonoDevelop.app\Contents\MacOS\lib\monodevelop\AddIns\MonoDevelop.Refactoring\MonoDevelop.Refactoring.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="Mono.Posix" />
     <Reference Include="MonoDevelop.Core">
       <HintPath>\Applications\MonoDevelop.app\Contents\MacOS\lib\monodevelop\bin\MonoDevelop.Core.dll</HintPath>
@@ -57,6 +45,18 @@
     </Reference>
     <Reference Include="ICSharpCode.NRefactory">
       <HintPath>\Applications\MonoDevelop.app\Contents\MacOS\lib\monodevelop\bin\ICSharpCode.NRefactory.dll</HintPath>
+    </Reference>
+    <Reference Include="Mono.TextEditor, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>\Applications\MonoDevelop.app\Contents\MacOS\lib\monodevelop\bin\Mono.TextEditor.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="MonoDevelop.DesignerSupport, Version=2.6.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>\Applications\MonoDevelop.app\Contents\MacOS\lib\monodevelop\AddIns\MonoDevelop.DesignerSupport\MonoDevelop.DesignerSupport.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="MonoDevelop.Refactoring, Version=2.6.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>\Applications\MonoDevelop.app\Contents\MacOS\lib\monodevelop\AddIns\MonoDevelop.Refactoring\MonoDevelop.Refactoring.dll</HintPath>
+      <Private>False</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/HaxeBinding/HaxeBinding.csproj
+++ b/HaxeBinding/HaxeBinding.csproj
@@ -37,23 +37,26 @@
     <Reference Include="gdk-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f" />
     <Reference Include="System.Xml" />
     <Reference Include="Mono.TextEditor, Version=1.0.0.0, Culture=neutral">
+      <HintPath>\Applications\MonoDevelop.app\Contents\MacOS\lib\monodevelop\bin\Mono.TextEditor.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="MonoDevelop.DesignerSupport, Version=2.6.0.0, Culture=neutral">
+      <HintPath>\Applications\MonoDevelop.app\Contents\MacOS\lib\monodevelop\AddIns\MonoDevelop.DesignerSupport\MonoDevelop.DesignerSupport.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="MonoDevelop.Refactoring, Version=2.6.0.0, Culture=neutral">
+      <HintPath>\Applications\MonoDevelop.app\Contents\MacOS\lib\monodevelop\AddIns\MonoDevelop.Refactoring\MonoDevelop.Refactoring.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Mono.Posix" />
     <Reference Include="MonoDevelop.Core">
-      <HintPath>..\..\..\..\..\..\Applications\MonoDevelop.app\Contents\MacOS\lib\monodevelop\bin\MonoDevelop.Core.dll</HintPath>
+      <HintPath>\Applications\MonoDevelop.app\Contents\MacOS\lib\monodevelop\bin\MonoDevelop.Core.dll</HintPath>
     </Reference>
     <Reference Include="MonoDevelop.Ide">
-      <HintPath>..\..\..\..\..\..\Applications\MonoDevelop.app\Contents\MacOS\lib\monodevelop\bin\MonoDevelop.Ide.dll</HintPath>
+      <HintPath>\Applications\MonoDevelop.app\Contents\MacOS\lib\monodevelop\bin\MonoDevelop.Ide.dll</HintPath>
     </Reference>
     <Reference Include="ICSharpCode.NRefactory">
-      <HintPath>..\..\..\..\..\..\Applications\MonoDevelop.app\Contents\MacOS\lib\monodevelop\bin\ICSharpCode.NRefactory.dll</HintPath>
+      <HintPath>\Applications\MonoDevelop.app\Contents\MacOS\lib\monodevelop\bin\ICSharpCode.NRefactory.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/HaxeBinding/Tools/HaxeCompilerManager.cs
+++ b/HaxeBinding/Tools/HaxeCompilerManager.cs
@@ -275,9 +275,13 @@ namespace MonoDevelop.HaxeBinding.Tools
 		                var client = new TcpClient("127.0.0.1", port);
 		                var writer = new StreamWriter(client.GetStream());
 		                writer.WriteLine("--cwd " + project.BaseDirectory);
-						string[] argList = args.Split (' ');
-		                foreach (var arg in argList)
-		                    writer.WriteLine(arg);
+		                
+		                // Instead of replacing spaces with newlines, replace only
+		                // if the space is followed by a dash.
+		                // TODO: Even more intelligent replacement so you can use folders
+						// 		 that contain the string sequence " -".
+						writer.Write(args.Replace(" -", "\n-"));
+						
 						//writer.WriteLine("--connect " + port);
 		                writer.Write("\0");
 		                writer.Flush();

--- a/HaxeBinding/gtk-gui/gui.stetic
+++ b/HaxeBinding/gtk-gui/gui.stetic
@@ -5,8 +5,8 @@
     <target-gtk-version>2.12</target-gtk-version>
   </configuration>
   <import>
-    <widget-library name="../../../../../../../Applications/MonoDevelop.app/Contents/MacOS/lib/monodevelop/bin/MonoDevelop.Ide.dll" />
-    <widget-library name="../bin/Release/MonoDevelop.HaxeBinding.dll" internal="true" />
+    <widget-library name="/Applications/MonoDevelop.app/Contents/MacOS/lib/monodevelop/bin/MonoDevelop.Ide.dll" />
+    <widget-library name="../bin/Debug/MonoDevelop.HaxeBinding.dll" internal="true" />
   </import>
   <widget class="Gtk.Bin" id="MonoDevelop.HaxeBinding.Projects.Gui.NMEOutputOptionsWidget" design-size="467 300">
     <property name="MemberName" />

--- a/HaxeBinding/gtk-gui/gui.stetic
+++ b/HaxeBinding/gtk-gui/gui.stetic
@@ -5,6 +5,9 @@
     <target-gtk-version>2.12</target-gtk-version>
   </configuration>
   <import>
+    <widget-library name="/Applications/MonoDevelop.app/Contents/MacOS/lib/monodevelop/bin/Mono.TextEditor.dll" />
+    <widget-library name="/Applications/MonoDevelop.app/Contents/MacOS/lib/monodevelop/AddIns/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.dll" />
+    <widget-library name="/Applications/MonoDevelop.app/Contents/MacOS/lib/monodevelop/AddIns/MonoDevelop.Refactoring/MonoDevelop.Refactoring.dll" />
     <widget-library name="/Applications/MonoDevelop.app/Contents/MacOS/lib/monodevelop/bin/MonoDevelop.Ide.dll" />
     <widget-library name="../bin/Debug/MonoDevelop.HaxeBinding.dll" internal="true" />
   </import>


### PR DESCRIPTION
There was a bug that classpaths weren't allowed to contain spaces. Previously, NME sent the parameters to be used on the haxe completion server with newline-characters, which got later replaced by spaces and in the end all spaces were replaced by newlines. This caused "normal" spaces that always were spaces to become newline-characters.

I fixed it by only replacing spaces that are followed by a dash to be replaced by newlines, but obviously a cleaner method would be to not even replace the newline-characters of NME with spaces and never do those conversions. However, since NME doesn't seem to be the only used source for the haxe parameters, I just did the quick and dirty method instead of changing all spaces from the other sources to newlines.

(Besides that, another commit changed some relative paths in references of the hidden files (e.g. the .csproj) to absolute paths so they'd work on every platform regardless of the location of the git clone)

Best regards,
Robert 'rynti' Böhm
